### PR TITLE
docs: add architecture and Realm sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,55 @@ The manager consumes rules and schemas published at
 | Bootstrap schema | `https://steerspec.dev/schemas/entity/bootstrap.json` |
 | Rules manifest | `https://steerspec.dev/rules/latest/index.json` |
 | Versioned rules | `https://steerspec.dev/rules/v<version>/` |
+
+## Architecture
+
+The manager is the **core engine** in the SteerSpec 3-tier architecture:
+
+```
+strspc-rules          (data: JSON rules + schemas)
+     │
+     ▼
+strspc-manager        (core engine, Go, OSS)   ◄── this repo
+     │
+     ├──────────────────┐
+     ▼                  ▼
+strspc-CLI           strspc-cloud
+(developer tool)     (paid SaaS)
+```
+
+All validation and evaluation logic lives here. The CLI and cloud service
+call into the manager — they never implement rule logic directly.
+
+See [strspc-rules#17](https://github.com/SteerSpec/strspc-rules/issues/17)
+for the full architecture decision.
+
+## Modules
+
+| Module | Type | Description |
+| ------ | ---- | ----------- |
+| `rule-lint` | deterministic, stateless | Validates entity files against schema and lifecycle rules |
+| `rule-diff` | deterministic, stateful | Validates rule changes across PR diffs |
+| `rule-eval` | AI, pluggable providers | Evaluates code compliance against rules |
+| `rule-resolve` | deterministic | Fetches, caches, and resolves rules from configured sources |
+| `realm-lint` | deterministic, stateless | Validates Realm structure, manifest, and EUID uniqueness |
+| `realm-resolve` | deterministic | Resolves Realm dependencies and fetches remote Realms |
+
+## Realms
+
+Rules are organized into **Realms** — namespaces where Entity Unique Identifiers
+(EUIDs) are unique. A Realm is any directory containing entity files and a
+`realm.json` manifest:
+
+- `strspc-rules/rules/core/` — the **core** Realm (ships with SteerSpec)
+- An org spec repo — an **organizational** Realm
+- `./rules/` in a consumer project — a **local** Realm
+
+See [strspc-rules#19](https://github.com/SteerSpec/strspc-rules/issues/19)
+for the full Realm architecture.
+
+## References
+
+- [strspc-rules#4](https://github.com/SteerSpec/strspc-rules/issues/4) — Rule Manager specification
+- [strspc-rules#17](https://github.com/SteerSpec/strspc-rules/issues/17) — 3-tier platform architecture
+- [strspc-rules#19](https://github.com/SteerSpec/strspc-rules/issues/19) — Realm formalization


### PR DESCRIPTION
## Summary

- Add **Architecture** section with 3-tier diagram showing strspc-manager's role as the core engine ([strspc-rules#17](https://github.com/SteerSpec/strspc-rules/issues/17))
- Add **Modules** table documenting all 6 modules (rule-lint, rule-diff, rule-eval, rule-resolve, realm-lint, realm-resolve)
- Add **Realms** section explaining the namespace concept ([strspc-rules#19](https://github.com/SteerSpec/strspc-rules/issues/19))
- Add **References** linking to canonical architecture issues

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all issue links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)